### PR TITLE
Switched to a better battle tested shallowEquality check

### DIFF
--- a/.size-snapshot.json
+++ b/.size-snapshot.json
@@ -1,8 +1,8 @@
 {
   "dist/index.js": {
-    "bundled": 1904,
-    "minified": 852,
-    "gzipped": 408,
+    "bundled": 1877,
+    "minified": 829,
+    "gzipped": 394,
     "treeshaked": {
       "rollup": {
         "code": 14,
@@ -14,8 +14,8 @@
     }
   },
   "dist/index.cjs.js": {
-    "bundled": 2692,
-    "minified": 1207,
-    "gzipped": 482
+    "bundled": 2665,
+    "minified": 1184,
+    "gzipped": 469
   }
 }

--- a/tests/test.js
+++ b/tests/test.js
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react'
+import React, { useEffect, useRef } from 'react'
 import { cleanup, render } from 'react-testing-library'
 import create from '../src/index'
 
@@ -15,13 +15,21 @@ it('creates an HTML element from a tag name', () => {
 
   function Counter() {
     const { count, inc, dec } = useStore()
+
+    const renderCount = useRef(0)
     useEffect(() => {
       dec()
     }, [])
 
     console.log('r', count)
-
-    expect(count).toBe(1)
+    useEffect(() => {
+      if (renderCount.current === 0) {
+        expect(count).toBe(1)
+      } else if (renderCount.current >= 1) {
+        expect(count).toBe(0)
+      }
+    })
+    useEffect(() => void ++renderCount.current)
     return count
   }
 


### PR DESCRIPTION
The code this library currently uses to shallow check state equality has a potential bug.

```js
if (sliceRef.current !== selected && selected === Object(selected)) {
            selected = Object.entries(selected).reduce(
              (acc, [key, value]) =>
                sliceRef.current[key] !== value
                  ? Object.assign({}, acc, { [key]: value })
                  : acc,
              sliceRef.current
            )
          }
```

In the event that sliceRef.current has a property that was later deleted in a global state update, this ghost property would remain in the new selected which can cause issues if the component has logic that depends on the presence or absence of that property.


Example:

```js
let test = (prevState, newState) => {
    if (prevState !== newState && newState === Object(newState)) {
            newState = Object.entries(newState).reduce(
              (acc, [key, value]) =>
                prevState[key] !== value
                  ? Object.assign({}, acc, { [key]: value })
                  : acc,
              prevState
            );
            return newState
          }
    return prevState
}


test( { a: 1, b: 2, c: 3 }, { a: 4, b: 5 } );  // -> { a: 4, b: 5, c: 3 }
// `c` is still there even though it shouldn't be

```

This can also happen with dynamic selectors such as those that change the selected state depending on component `props`  which can cause a difficult to debug situation.

This PR copies the battle tested `shallowEqual` code used by `react-redux`, and for some reason this reduces the overall bundle size despite having slightly more lines of code?