### PR TITLE
Updating typo in README

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -48,7 +48,7 @@ function Controls() {
 }
 ```
 
-# Receipes
+# Recipes
 
 ## Fetching everything
 


### PR DESCRIPTION
Small typo `Receipes` should be `Recipes`  