### PR TITLE
Update refs in useEffect, add more tests, fix pre-commit lint

### DIFF
--- a/.size-snapshot.json
+++ b/.size-snapshot.json
@@ -1,8 +1,8 @@
 {
   "dist/esm/index.js": {
-    "bundled": 2298,
-    "minified": 910,
-    "gzipped": 483,
+    "bundled": 2417,
+    "minified": 898,
+    "gzipped": 470,
     "treeshaked": {
       "rollup": {
         "code": 14,
@@ -14,8 +14,8 @@
     }
   },
   "dist/cjs/index.js": {
-    "bundled": 2763,
-    "minified": 1146,
-    "gzipped": 545
+    "bundled": 2888,
+    "minified": 1140,
+    "gzipped": 540
   }
 }

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "printWidth": 80
   },
   "lint-staged": {
-    "*.{js,}": [
+    "*.{js,ts,tsx}": [
       "prettier --write",
       "git add"
     ]

--- a/src/index.ts
+++ b/src/index.ts
@@ -45,9 +45,13 @@ export default function create<
     // Prevent useEffect from needing to run when values change by storing them in a ref object
     const refs = React.useRef({ stateSlice, selectState }).current
 
-    if (refs.stateSlice !== stateSlice) refs.stateSlice = stateSlice
-    if (refs.selectState !== selectState) refs.selectState = selectState
+    // Update refs when needed and only after view has been updated
+    React.useEffect(() => {
+      refs.stateSlice = stateSlice
+      refs.selectState = selectState
+    }, [stateSlice, selectState])
 
+    // Subscribe/unsubscribe to the store only on mount/unmount
     React.useEffect(() => {
       return subscribe(() => {
         // Get fresh selected state

--- a/tests/test.tsx
+++ b/tests/test.tsx
@@ -87,3 +87,59 @@ it('can subscribe to part of the store', async () => {
   expect(counterRenderCount).toBe(2)
   expect(controlsRenderCount).toBe(1)
 })
+
+it('can get the store', () => {
+  const [, { getState }] = create((set, get) => ({
+    value: 1,
+    getState1: get,
+    getState2: () => getState(),
+  }))
+
+  expect(getState().getState1().value).toBe(1)
+  expect(getState().getState2().value).toBe(1)
+})
+
+it('can set the store', () => {
+  const [, { getState, setState }] = create(set => ({
+    value: 1,
+    setState1: set,
+    setState2: newState => setState(newState),
+  }))
+
+  getState().setState1({ ...getState(), value: 2 })
+  expect(getState().value).toBe(2)
+  getState().setState2({ ...getState(), value: 3 })
+  expect(getState().value).toBe(3)
+})
+
+it('can subscribe to the store', () => {
+  expect.assertions(2)
+
+  const [, { setState, subscribe }] = create(() => ({ value: 1 }))
+
+  const unsub1 = subscribe(newState => {
+    expect(newState.value).toBe(2)
+    unsub1()
+  })
+  const unsub2 = subscribe(newState => {
+    expect(newState.value).toBe(2)
+    unsub2()
+  })
+
+  setState({ value: 2 })
+})
+
+it('can destroy the store', () => {
+  const [, { destroy, getState, setState, subscribe }] = create(() => ({
+    value: 1,
+  }))
+
+  subscribe(() => {
+    throw new Error('did not clear listener on destroy')
+  })
+  destroy()
+
+  // should this throw?
+  setState({ value: 2 })
+  expect(getState().value).toEqual(2)
+})


### PR DESCRIPTION
Just minor updates. Adding a test for `destroy` made me question something. The store can be used after `destroy` is called. Is this expected behavior?

Also, I did not update the package.json version. I noticed `yarn publish` gives you the option to bump the version when deploying the package so I figured I would leave that to @drcmda